### PR TITLE
Ignore golang.org/x/text updates without using a blob

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
         "gomod"
       ],
       "matchPackageNames": [
-        "@golang.org/x/**",
+        "golang.org/x/text",
         "gopkg.in/yaml.v3",
         "github.com/google/pprof"
       ]


### PR DESCRIPTION
Apperantly this isn't the syntax that should be used for a blob as it isn't working, but we only have this library either way so - let's just put it directly.