### PR TITLE
ftoa: fix shortest-mode carry mis-port corrupting round-up-to-9 doubles

### DIFF
--- a/ftoa/ftoa.go
+++ b/ftoa/ftoa.go
@@ -536,7 +536,15 @@ func ftoa(d float64, mode int, biasUp bool, ndigits int, buf []byte) ([]byte, in
 					b.Lsh(b, 1)
 					j1 = b.Cmp(S)
 					if (j1 > 0) || (j1 == 0 && (((dig & 1) == 1) || biasUp)) {
-						dig++
+						// Carry propagation (the round_9_up path in the original
+						// dtoa.c) applies only when the digit was ALREADY '9'
+						// before rounding up: `dig++ == '9'` in C compares the
+						// pre-increment value. Checking the post-increment value
+						// here made every round-up that lands ON '9' (dig was
+						// '8') round a second time via roundOff, emitting a
+						// one-digit-short string outside the half-ulp interval
+						// (e.g. 0.7016570306969449 -> "0.701657030696945",
+						// which does not parse back to the same float64).
 						if dig == '9' {
 							buf = append(buf, '9')
 							buf, flag := roundOff(buf, startPos)
@@ -546,6 +554,7 @@ func ftoa(d float64, mode int, biasUp bool, ndigits int, buf []byte) ([]byte, in
 							}
 							return buf, k + 1
 						}
+						dig++
 					}
 				}
 				buf = append(buf, dig)

--- a/ftoa/ftostr_test.go
+++ b/ftoa/ftostr_test.go
@@ -2,6 +2,7 @@ package ftoa
 
 import (
 	"math"
+	"math/rand"
 	"strconv"
 	"testing"
 )
@@ -88,5 +89,40 @@ func BenchmarkAppendFloatSmall(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		strconv.AppendFloat(buf[:0], math.Pi, 'e', -1, 64)
+	}
+}
+
+// TestDtostrShortestRoundTrip pins the mode-0 (shortest) contract required by
+// ECMAScript Number::toString: the produced string must parse back to exactly
+// the input float64. Before the fix, the closest-digit choice in the bignum
+// fallback propagated a carry whenever rounding up landed ON '9' (a mis-port
+// of dtoa.c's `dig++ == '9'` post-increment test), producing a one-digit-short
+// string outside the half-ulp interval for ~1 in 15,000 doubles.
+func TestDtostrShortestRoundTrip(t *testing.T) {
+	// Known pre-fix corruptions (all end in a round-up-to-9 final digit).
+	for _, d := range []float64{
+		0.7016570306969449, // rendered "0.701657030696945" before the fix
+		0.24414061428229689,
+		0.5084920399817559,
+		0.19243255639630719,
+		0.5342431914336429,
+		0.9868917361939819,
+	} {
+		got := string(FToStr(d, ModeStandard, 0, nil))
+		want := strconv.FormatFloat(d, 'g', -1, 64)
+		if back, _ := strconv.ParseFloat(got, 64); back != d {
+			t.Errorf("FToStr(%v, ModeStandard) = %q, does not round-trip (Go shortest: %q)", d, got, want)
+		}
+	}
+
+	// Differential check against the Go standard library's shortest formatter
+	// (a round-trip oracle) over a deterministic pseudo-random sample.
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 500000; i++ {
+		d := rng.Float64()
+		got := string(FToStr(d, ModeStandard, 0, nil))
+		if back, err := strconv.ParseFloat(got, 64); err != nil || back != d {
+			t.Fatalf("FToStr(%v, ModeStandard) = %q does not round-trip (err=%v)", d, got, err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`Number::toString` / `JSON.stringify` produce a string that does not parse back to the same float64 for ~1 in 15,000 doubles:

```js
(0.7016570306969449).toString() // sobek: "0.701657030696945" — a DIFFERENT float64
                                // V8/spec: "0.7016570306969449"
```

ECMAScript NumberToString requires the digits to round-trip exactly. `0.701657030696945` is outside the half-ulp interval of the input (upper bound `0.7016570306969449055…`), so `JSON.parse(JSON.stringify(x)) !== x`.

## Root cause

In the bignum fallback of dtoa mode 0 (`ftoa/ftoa.go`, the closest-digit choice inside the Steele & White loop), the original dtoa.c reads:

```c
if ((j1 > 0 || (j1 == 0 && (dig & 1 || bias_up))) && dig++ == '9')
    goto round_9_up;
```

`dig++ == '9'` compares the **pre-increment** value: carry propagation applies only when the digit was already '9' before rounding up. The Go port increments first and then tests the **post-increment** value, so every round-up that lands ON '9' (dig was '8') is routed through `roundOff` and rounded a second time, emitting a one-digit-short string outside the tolerance interval. Every corrupted double is exactly one whose correct shortest repr ends in a round-up-to-9.

The bug only shows when the Grisu fast path bails (`fast.Dtoa` ok=false), which is why it is rare. It reproduces identically in upstream goja (same port).

## Fix

Move the '9' test before the increment, matching dtoa.c. With the fix, a 200k-sample differential test against Go's `strconv` shortest formatter (a round-trip oracle) has zero mismatches for normal doubles (previously 13/200k); the existing ftoa and root-package test suites pass unchanged.

Found via a byte-fidelity round-trip property test in a downstream project whose values cross the sobek boundary.