### PR TITLE
ftoa: fix shortest-mode carry mis-port (dtoa.c round_9_up)

### DIFF
--- a/ftoa/ftoa.go
+++ b/ftoa/ftoa.go
@@ -536,7 +536,12 @@ func ftoa(d float64, mode int, biasUp bool, ndigits int, buf []byte) ([]byte, in
 					b.Lsh(b, 1)
 					j1 = b.Cmp(S)
 					if (j1 > 0) || (j1 == 0 && (((dig & 1) == 1) || biasUp)) {
-						dig++
+						// dtoa.c guards round_9_up with `dig++ == '9'`: it tests the
+						// pre-increment digit, then increments as a side effect. Carry only
+						// when the digit WAS already '9'; otherwise append the incremented
+						// digit on fall-through. The prior port tested the post-increment
+						// value, wrongly carrying a correct 8->9 round-up and dropping a
+						// digit (+1 ulp). Matches the two sibling dig=='9' sites here.
 						if dig == '9' {
 							buf = append(buf, '9')
 							buf, flag := roundOff(buf, startPos)
@@ -546,6 +551,7 @@ func ftoa(d float64, mode int, biasUp bool, ndigits int, buf []byte) ([]byte, in
 							}
 							return buf, k + 1
 						}
+						dig++
 					}
 				}
 				buf = append(buf, dig)


### PR DESCRIPTION
The `j<0` branch in `ftoa()` inverted dtoa.c's `round_9_up` carry guard.

dtoa.c uses `dig++ == '9'`, a post-increment that tests the **pre-increment**
digit and increments as a side effect: it carries into `round_9_up` only when the
digit was already `'9'`, otherwise the incremented digit is appended on the
fall-through. This port did `dig++` first, then tested `dig == '9'`, which fires
when the digit **was `'8'`** — wrongly turning a correct 8→9 round-up into a
carry+truncate that drops the final digit (+1 ulp).

Concretely, `JSON.stringify(0.7016570306969449)` returned `"0.701657030696945"`
(15 digits — a *different* float) instead of the correct 16-digit shortest
representation that round-trips. Cross-checked against V8/Node, which returns the
16-digit form.

Fix: test `dig == '9'` **before** incrementing, matching dtoa.c's post-increment
semantics and the two sibling `dig == '9'` checks already present in the same
function (the `j1==0 && mode==0` site and the `j1>0` site).

Refs #142.